### PR TITLE
Multi target framework support net core 2.1

### DIFF
--- a/FirebaseAuth/FirebaseAuth.csproj
+++ b/FirebaseAuth/FirebaseAuth.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
     <Description>Firebase .NET Token Generation and Verification. This library supports Firebase v3. See docs for installation instructions and usage.</Description>
     <Company />
     <Authors>Greg Taylor</Authors>

--- a/FirebaseAuth/FirebaseAuth.csproj
+++ b/FirebaseAuth/FirebaseAuth.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+   <!-- TargetFrameworks Oficial Reference: https://docs.microsoft.com/en-us/dotnet/standard/frameworks -->
     <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Version>2.0.5</Version>
     <Description>Firebase .NET Token Generation and Verification. This library supports Firebase v3. See docs for installation instructions and usage.</Description>

--- a/FirebaseAuth/FirebaseAuth.csproj
+++ b/FirebaseAuth/FirebaseAuth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netstandard2.0</TargetFrameworks>
     <Version>2.0.4</Version>
     <Description>Firebase .NET Token Generation and Verification. This library supports Firebase v3. See docs for installation instructions and usage.</Description>
     <Company />


### PR DESCRIPTION
TargetFrameworks Oficial Reference: https://docs.microsoft.com/en-us/dotnet/standard/frameworks

Added TargetFrameworks support and enable to be use it by net core 2.1 